### PR TITLE
Release 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: rust
+rust:
+  - nightly
+  - beta
+  - stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mitochondria"
-version = "0.3.2"
+version = "1.0.0"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 description = "Mitochondria is the powerhouse of the `Cell`"
 repository = "https://github.com/nox/mitochondria"

--- a/src/once.rs
+++ b/src/once.rs
@@ -12,18 +12,32 @@ mod core {
     unsafe impl<T> Send for OnceCell<T> where T: Send {}
 
     impl<T> OnceCell<T> {
-        /// Creates a new `OnceCell` that may already be initialized.
+        /// Creates a new `OnceCell`.
         ///
-        /// # Example
+        /// # Examples
         ///
         /// ```
         /// use mitochondria::OnceCell;
         ///
-        /// let c = OnceCell::new(Some("Hello vesicle!".to_owned()));
+        /// let c = OnceCell::<String>::new();
         /// ```
         #[inline]
-        pub fn new(value: Option<T>) -> Self {
-            OnceCell(UnsafeCell::new(value))
+        pub fn new() -> Self {
+            OnceCell(UnsafeCell::new(None))
+        }
+
+        /// Creates a new `OnceCell` initialised with `value`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use mitochondria::OnceCell;
+        ///
+        /// let c = OnceCell::new_with_value(Some("Hello vesicle!".to_owned()));
+        /// ```
+        #[inline]
+        pub fn new_with_value(value: T) -> Self {
+            OnceCell(UnsafeCell::new(Some(value)))
         }
 
         /// Calls a function to try to initialize this cell.
@@ -40,11 +54,11 @@ mod core {
         /// ```
         /// use mitochondria::OnceCell;
         ///
-        /// let c = OnceCell::new(None);
+        /// let c = OnceCell::new();
         ///
-        /// assert_eq!(c.try_init_once(|| Err(())), None);
+        /// assert_eq!(c.try_init_once(|| Err(())), Err(()));
         ///
-        /// let greeting: &str = c.try_init_once(|| {
+        /// let greeting = c.try_init_once::<(), _>(|| {
         ///     Ok("Hello ribosome!".to_owned())
         /// }).unwrap();
         /// ```
@@ -52,45 +66,74 @@ mod core {
         /// ```
         /// use mitochondria::OnceCell;
         ///
-        /// let c = OnceCell::new(Some("Hello reticulum!".to_owned()));
+        /// let c = OnceCell::new_with_value("Hello reticulum!".to_owned());
         ///
         /// // Calls to `try_init_once` on initialized cells are ignored.
-        /// assert_eq!(c.try_init_once(|| Ok("Goodbye!".to_owned())).unwrap(),
-        ///            "Hello reticulum!");
+        /// assert_eq!(
+        ///     c.try_init_once::<(), _>(|| Ok("Goodbye!".to_owned())).unwrap(),
+        ///     "Hello reticulum!");
         /// ```
-        #[allow(unsafe_code)]
         #[inline]
-        pub fn try_init_once<F>(&self, f: F) -> Option<&T>
-            where F: FnOnce() -> Result<T, ()>
+        pub fn try_init_once<E, F>(&self, f: F) -> Result<&T, E>
+            where F: FnOnce() -> Result<T, E>
         {
-            if self.borrow().is_none() {
-                if let Ok(value) = f() {
-                    // f() may have initialised the value already.
-                    if self.borrow().is_none() {
-                        unsafe { *self.0.get() = Some(value); }
-                    }
-                }
+            if let Some(value) = self.as_ref() {
+                // The cell was already initialised.
+                return Ok(value);
             }
-            self.borrow()
+            let result = f();
+            // Even if f() returned an error, the function may have initialised
+            // the cell in a reentrant way, so we need to check again.
+            if let Some(value) = self.as_ref() {
+                return Ok(value);
+            }
+            let value = try!(result);
+            unsafe { *self.0.get() = Some(value); }
+            Ok(self.as_ref().unwrap())
         }
 
-        /// Borrows the contained value, if initialized.
+        /// Returns `None` if the cell is not initialised, or else returns a
+        /// reference to the value wrapped in `Some`.
         ///
         /// # Examples
         ///
         /// ```
         /// use mitochondria::OnceCell;
         ///
-        /// let c = OnceCell::new(None);
+        /// let c = OnceCell::new();
         ///
-        /// assert!(c.borrow().is_none());
+        /// assert!(c.as_ref().is_none());
         ///
         /// let greeting = c.init_once(|| "Hello nucleus!".to_owned());
-        /// assert_eq!(c.borrow(), Some(greeting));
+        /// assert_eq!(c.as_ref(), Some(greeting));
         /// ```
         #[inline]
-        pub fn borrow(&self) -> Option<&T> {
+        pub fn as_ref(&self) -> Option<&T> {
             unsafe { (*self.0.get()).as_ref() }
+        }
+
+        /// Returns `None` if the cell is not initialised, or else returns a
+        /// mutable reference to the value wrapped in `Some`.
+        ///
+        /// This call borrows `OnceCell` mutably (at compile-time) which
+        /// guarantees that we possess the only reference.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use mitochondria::OnceCell;
+        ///
+        /// let mut c = OnceCell::new();
+        ///
+        /// assert!(c.as_mut().is_none());
+        ///
+        /// c.init_once(|| "Nucleo".to_owned());
+        /// *c.as_mut().unwrap() += "lus!";
+        /// assert_eq!(c.as_ref().unwrap(), "Nucleolus!");
+        /// ```
+        #[inline]
+        pub fn as_mut(&mut self) -> Option<&mut T> {
+            unsafe { (*self.0.get()).as_mut() }
         }
     }
 }
@@ -106,7 +149,7 @@ impl<T> OnceCell<T> {
     /// ```
     /// use mitochondria::OnceCell;
     ///
-    /// let c = OnceCell::new(None);
+    /// let c = OnceCell::new();
     ///
     /// let greeting: &str = c.init_once(|| "Hello ribosome!".to_owned());
     /// ```
@@ -114,35 +157,46 @@ impl<T> OnceCell<T> {
     /// ```
     /// use mitochondria::OnceCell;
     ///
-    /// let c = OnceCell::new(Some("Hello reticulum!".to_owned()));
+    /// let c = OnceCell::new_with_value("Hello reticulum!".to_owned());
     ///
     /// // Calls to `init_once` on initialized cells are ignored.
-    /// assert_eq!(c.init_once(|| "Goodbye!".to_owned()),
-    ///            "Hello reticulum!");
+    /// assert_eq!(
+    ///     c.init_once(|| "Goodbye!".to_owned()),
+    ///     "Hello reticulum!");
     /// ```
     #[inline]
     pub fn init_once<F>(&self, f: F) -> &T where F: FnOnce() -> T {
-        self.try_init_once(|| Ok(f())).unwrap()
+        self.try_init_once(|| Ok::<T, ()>(f())).unwrap()
     }
 }
 
 impl<T: Clone> Clone for OnceCell<T> {
     #[inline]
     fn clone(&self) -> Self {
-        OnceCell::new(self.borrow().cloned())
+        self.as_ref()
+            .cloned()
+            .map(OnceCell::new_with_value)
+            .unwrap_or(OnceCell::new())
     }
 }
 
 impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("OnceCell").field(&self.borrow()).finish()
+        f.debug_tuple("OnceCell").field(&self.as_ref()).finish()
     }
 }
 
 impl<T> Default for OnceCell<T> {
     #[inline]
     fn default() -> Self {
-        OnceCell::new(None)
+        OnceCell::new()
+    }
+}
+
+impl<T> From<T> for OnceCell<T> {
+    #[inline]
+    fn from(value: T) -> Self {
+        OnceCell::new_with_value(value)
     }
 }
 
@@ -151,14 +205,105 @@ mod tests {
     use OnceCell;
 
     #[test]
-    fn reentrancy() {
-        let c = OnceCell::new(None);
+    fn smoketest() {
+        let x = OnceCell::new();
+        assert_eq!(x.as_ref(), None);
+        assert_eq!(x.init_once(|| "ribosome"), &"ribosome");
+        assert_eq!(x.as_ref(), Some(&"ribosome"));
+        assert_eq!(x.init_once(|| "nucleolus"), &"ribosome");
+        assert_eq!(x.as_ref(), Some(&"ribosome"));
+        assert_eq!(
+            x.try_init_once::<(), _>(|| Ok("nucleolus")),
+            Ok(&"ribosome"));
+        assert_eq!(x.as_ref(), Some(&"ribosome"));
 
-        let value = *c.init_once(|| {
+        let y = OnceCell::new();
+        assert_eq!(y.try_init_once(|| Err(())), Err(()));
+        assert_eq!(
+            y.try_init_once::<(), _>(|| Ok("ribosome")),
+            Ok(&"ribosome"));
+        assert_eq!(y.as_ref(), Some(&"ribosome"));
+        assert_eq!(
+            y.try_init_once::<(), _>(|| Ok("nucleolus")),
+            Ok(&"ribosome"));
+        assert_eq!(y.as_ref(), Some(&"ribosome"));
+        assert_eq!(y.init_once(|| "nucleolus"), &"ribosome");
+        assert_eq!(y.as_ref(), Some(&"ribosome"));
+
+        let z = OnceCell::new_with_value("ribosome");
+        assert_eq!(z.as_ref(), Some(&"ribosome"));
+    }
+
+    #[test]
+    fn clone() {
+        let x = OnceCell::new();
+        assert_eq!(x.clone().as_ref(), None);
+        x.init_once(|| "ribosome");
+        assert_eq!(x.clone().as_ref(), Some(&"ribosome"));
+    }
+
+    #[test]
+    fn debug() {
+        let x = OnceCell::new();
+        assert_eq!(format!("{:?}", x), "OnceCell(None)");
+        x.init_once(|| "ribosome");
+        assert_eq!(format!("{:?}", x), "OnceCell(Some(\"ribosome\"))");
+    }
+
+    #[test]
+    fn default() {
+        let x = OnceCell::<String>::default();
+        assert_eq!(x.as_ref(), None);
+    }
+
+    #[test]
+    fn from() {
+        let x = OnceCell::from("ribosome");
+        assert_eq!(x.as_ref(), Some(&"ribosome"));
+    }
+
+    #[test]
+    fn send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<OnceCell<String>>();
+    }
+
+    #[test]
+    fn init_once_reentrancy() {
+        let c = OnceCell::new();
+
+        let value = c.init_once(|| {
             c.init_once(|| "ribosome");
             "nucleolus"
         });
 
-        assert_eq!(value, "ribosome");
+        assert_eq!(value, &"ribosome");
+        assert_eq!(c.as_ref(), Some(&"ribosome"));
+    }
+
+    #[test]
+    fn try_init_once_reentrancy() {
+        let c = OnceCell::new();
+
+        let value = c.try_init_once::<(), _>(|| {
+            let _ = c.try_init_once::<(), _>(|| Ok("ribosome"));
+            Ok("nucleolus")
+        });
+
+        assert_eq!(value, Ok(&"ribosome"));
+        assert_eq!(c.as_ref(), Some(&"ribosome"));
+    }
+
+    #[test]
+    fn try_init_once_error_reentrancy() {
+        let c = OnceCell::new();
+
+        let value = c.try_init_once::<(), _>(|| {
+            c.init_once(|| "ribosome");
+            Err(())
+        });
+
+        assert_eq!(value, Ok(&"ribosome"));
+        assert_eq!(c.as_ref(), Some(&"ribosome"));
     }
 }


### PR DESCRIPTION
This is now stable!

Changes from 0.3.2:
- MoveCell is now a structure.
- MoveCell::into_inner() is new.
- MoveCell::as_ptr() is new.
- MoveCell::as_mut() is new.
- MoveCell::set() is gone.
- MoveCell::take() is gone.
- OnceCell is now a structure.
- OnceCell::new() now takes no argument.
- OnceCell::new_with_value() can be used to create an already-initialised cell.
- OnceCell::try_init_once() return type has been changed to Result<T, E> to
  propagate any error.
- OnceCell::borrow() has been renamed to OnceCell::as_ref()
- OnceCell::as_mut() is new.
- From<T> for OnceCell<T> is new.
- Everything is now tested.
